### PR TITLE
Integration Day Fixes - Ethan + Logan

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -21,18 +21,6 @@ void SerialDemo(void);
 
 int main(void)
 {
-  // Wait for Pi to fully boot before proceeding
-  while (1)
-  {
-    if (HAL_GPIO_ReadPin(GPIOC, GPIO_PIN_8) == GPIO_PIN_RESET)
-    {
-      HAL_Delay(1);
-    }
-    else
-    {
-      break;
-    }
-  }
 
   HAL_Init();
   SystemClockConfig();
@@ -41,6 +29,14 @@ int main(void)
   __HAL_RCC_GPIOC_CLK_ENABLE();
   __HAL_RCC_GPIOD_CLK_ENABLE();
   Serial_Init();
+
+  // Wait for Pi to fully boot before proceeding
+  while (HAL_GPIO_ReadPin(GPIOC, GPIO_PIN_8) == GPIO_PIN_RESET)
+  {
+    LOG_INFO("Waiting: %d", HAL_GPIO_ReadPin(GPIOC, GPIO_PIN_8));
+    HAL_Delay(10);
+  }
+
   Drill_Init();
   Encoder_Init();
   Limit_Switch_Init();

--- a/src/main.c
+++ b/src/main.c
@@ -30,7 +30,9 @@ int main(void)
   __HAL_RCC_GPIOD_CLK_ENABLE();
   Serial_Init();
 
-  // Wait for Pi to fully boot before proceeding
+  Motors_Init();
+  HAL_GPIO_WritePin(motorY.sleepPort, motorY.sleepPin, GPIO_PIN_RESET); // Sleep Y motor w/o initializing
+  HAL_GPIO_WritePin(motorZ.sleepPort, motorZ.sleepPin, GPIO_PIN_RESET); // Sleep Z motor w/o intializing
   while (HAL_GPIO_ReadPin(GPIOC, GPIO_PIN_8) == GPIO_PIN_RESET)
   {
     LOG_INFO("Waiting: %d", HAL_GPIO_ReadPin(GPIOC, GPIO_PIN_8));
@@ -40,7 +42,6 @@ int main(void)
   Drill_Init();
   Encoder_Init();
   Limit_Switch_Init();
-  Motors_Init();
   UART_Init();
   Utilities_Init();
 

--- a/src/main.c
+++ b/src/main.c
@@ -28,14 +28,14 @@ int main(void)
   __HAL_RCC_GPIOB_CLK_ENABLE();
   __HAL_RCC_GPIOC_CLK_ENABLE();
   __HAL_RCC_GPIOD_CLK_ENABLE();
-  Serial_Init();
 
+  // Wait for Pi to boot to avoid unintentional movement
+  Serial_Init();
   Motors_Init();
-  HAL_GPIO_WritePin(motorY.sleepPort, motorY.sleepPin, GPIO_PIN_RESET); // Sleep Y motor w/o initializing
-  HAL_GPIO_WritePin(motorZ.sleepPort, motorZ.sleepPin, GPIO_PIN_RESET); // Sleep Z motor w/o intializing
+  HAL_GPIO_WritePin(motorY.sleepPort, motorY.sleepPin, GPIO_PIN_RESET); // Unstall y motor
+  HAL_GPIO_WritePin(motorZ.sleepPort, motorZ.sleepPin, GPIO_PIN_RESET); // Unstall z motor
   while (HAL_GPIO_ReadPin(GPIOC, GPIO_PIN_8) == GPIO_PIN_RESET)
   {
-    LOG_INFO("Waiting: %d", HAL_GPIO_ReadPin(GPIOC, GPIO_PIN_8));
     HAL_Delay(10);
   }
 
@@ -46,7 +46,6 @@ int main(void)
   Utilities_Init();
 
   LOG_INFO("System Initialized");
-
   updateStateMachine("Unhomed");
   SystemHealthCheck();
 

--- a/src/main.c
+++ b/src/main.c
@@ -21,6 +21,19 @@ void SerialDemo(void);
 
 int main(void)
 {
+  // Wait for Pi to fully boot before proceeding
+  while (1)
+  {
+    if (HAL_GPIO_ReadPin(GPIOC, GPIO_PIN_8) == GPIO_PIN_RESET)
+    {
+      HAL_Delay(1);
+    }
+    else
+    {
+      break;
+    }
+  }
+
   HAL_Init();
   SystemClockConfig();
   __HAL_RCC_GPIOA_CLK_ENABLE();


### PR DESCRIPTION
Fixes made while Logan and Ethan were testing locomotion system
 - Added software to disable Nucleo until fully booted. This prevents unintentional axis movement while the Pi is booting
 - Once Pi is booted, Nucleo is allowed to proceed into the rest of the main loop