### PR TITLE
Limit Switch Repairs

### DIFF
--- a/include/limit_switch_hal.h
+++ b/include/limit_switch_hal.h
@@ -10,13 +10,13 @@ typedef struct
     uint16_t pin;
     GPIO_PinState Pin_state;
     uint32_t lastDebounceTime;
-} InterruptSwitch;
+} LimitSwitch;
 
-extern InterruptSwitch ySW_neg;
-extern InterruptSwitch ySW_pos;
-extern InterruptSwitch zSW_neg;
-extern InterruptSwitch zSW_pos;
-extern InterruptSwitch piSW;
+extern LimitSwitch ySW_neg;
+extern LimitSwitch ySW_pos;
+extern LimitSwitch zSW_neg;
+extern LimitSwitch zSW_pos;
+extern LimitSwitch piSW;
 
 void Limit_Switch_Init(void);
 

--- a/include/limit_switch_hal.h
+++ b/include/limit_switch_hal.h
@@ -9,6 +9,7 @@ typedef struct
     GPIO_TypeDef *port;
     uint16_t pin;
     GPIO_PinState Pin_state;
+    uint32_t lastDebounceTime;
 } InterruptSwitch;
 
 extern InterruptSwitch ySW_neg;

--- a/include/motor_hal.h
+++ b/include/motor_hal.h
@@ -34,8 +34,8 @@ typedef struct
     double currentRPM;            // RPM motor is currently running at
     double targetRPM;             // Steady-state RPM for current move
     bool isMoving;                // Is the motor moving?
-    InterruptSwitch posLS;        // Positive limit switch associated with the motor
-    InterruptSwitch negLS;        // Positive limit switch associated with the motor
+    LimitSwitch posLS;            // Positive limit switch associated with the motor
+    LimitSwitch negLS;            // Positive limit switch associated with the motor
 } Motor;
 
 extern Motor motorY;

--- a/src/controls.c
+++ b/src/controls.c
@@ -18,6 +18,7 @@ void checkMoveIsValid(double y, double z);
  */
 void locateWeed(double y)
 {
+    LOG_INFO("Positining for Removal");
     updateStateMachine("Positioning");
     MoveTo(y, Z_SAFE);
 }
@@ -30,9 +31,10 @@ void locateWeed(double y)
  */
 void removeWeed(double y, int drillPower)
 {
+    LOG_INFO("Removing Weed");
     updateStateMachine("Drilling");
     setDrillPower(drillPower, DRILLCCW);
-    MoveTo(y, motorZ.posMin);
+    MoveTo(y, -25); // Return to min position when done
     setDrillPower(0, DRILLCW);
     updateStateMachine("Positioning");
     MoveTo(y, Z_SAFE);
@@ -65,7 +67,7 @@ void MoveTo(double y, double z)
         HAL_Delay(1);
     }
 
-    PrintCartesianCoords();
+    // PrintCartesianCoords();
 }
 
 /**

--- a/src/controls.c
+++ b/src/controls.c
@@ -67,7 +67,7 @@ void MoveTo(double y, double z)
         HAL_Delay(1);
     }
 
-    // PrintCartesianCoords();
+    PrintCartesianCoords();
 }
 
 /**
@@ -133,10 +133,8 @@ void PrintCartesianCoords(void)
     int int_part2 = (int)z;
     int decimal_part2 = abs((int)((z - int_part2) * 1000)); // 3 decimal places
 
-    LOG_INFO("");
-    LOG_INFO("Current YZ Pos [mm]: ");
-    LOG_INFO("(%d.%d, %d.%d)", int_part, decimal_part, int_part2, decimal_part2);
-    LOG_INFO("");
+    LOG_INFO("Current YZ Pos [mm]: (%d.%d, %d.%d)",int_part, decimal_part, int_part2, decimal_part2);
+    //LOG_INFO("(%d.%d, %d.%d)", int_part, decimal_part, int_part2, decimal_part2);
 }
 
 /**

--- a/src/limit_switch_hal.c
+++ b/src/limit_switch_hal.c
@@ -7,41 +7,44 @@
 void EXTI9_5_IRQHandler(void);
 void Switch_Init(InterruptSwitch *interruptSW);
 
-#define LIMIT_SWITCH_DEBOUNCE_MS 20 // Tuned software debounce time
-#define DEBOUNCE_OK(last_time, now) ((now - last_time) > LIMIT_SWITCH_DEBOUNCE_MS)
+#define LIMIT_SWITCH_DEBOUNCE_MS 20
 
 InterruptSwitch ySW_pos =
-    {
-        .name = "ySwitchPos",
-        .port = GPIOB,
-        .pin = GPIO_PIN_9,
-        .lastDebounceTime = 0};
+{
+    .name = "ySwitchPos",
+    .port = GPIOB,
+    .pin = GPIO_PIN_9,
+    .lastDebounceTime = 0
+};
 
 InterruptSwitch ySW_neg =
-    {
-        .name = "ySwitchNeg",
-        .port = GPIOB,
-        .pin = GPIO_PIN_8,
-        .lastDebounceTime = 0};
+{
+    .name = "ySwitchNeg",
+    .port = GPIOB,
+    .pin = GPIO_PIN_8,
+    .lastDebounceTime = 0
+};
 
 InterruptSwitch zSW_pos =
-    {
-        .name = "zSwitchPos",
-        .port = GPIOB,
-        .pin = GPIO_PIN_6,
-        .lastDebounceTime = 0};
+{
+    .name = "zSwitchPos",
+    .port = GPIOB,
+    .pin = GPIO_PIN_6,
+    .lastDebounceTime = 0
+};
 
 InterruptSwitch zSW_neg =
-    {
-        .name = "zSwitchNeg",
-        .port = GPIOB,
-        .pin = GPIO_PIN_5,
-        .lastDebounceTime = 0};
+{
+    .name = "zSwitchNeg",
+    .port = GPIOB,
+    .pin = GPIO_PIN_5,
+    .lastDebounceTime = 0
+};
 
 /**
  * @brief Initializes the pins and state of the limit switch / pi interrupt.
  *
- * @param InterruptSwitch Interrupt switch object.
+ * @param interruptSW Interrupt switch object.
  */
 void Switch_Init(InterruptSwitch *interruptSW)
 {
@@ -57,7 +60,6 @@ void Switch_Init(InterruptSwitch *interruptSW)
 
 /**
  * @brief Initializes all the limit switches, called in main.
- *
  */
 void Limit_Switch_Init(void)
 {
@@ -72,7 +74,6 @@ void Limit_Switch_Init(void)
 
 /**
  * @brief Pins 5-9 interrupt handler, currently used for limit switches.
- *
  */
 void EXTI9_5_IRQHandler(void)
 {
@@ -87,20 +88,15 @@ void EXTI9_5_IRQHandler(void)
 
     uint32_t now = HAL_GetTick();
 
-    GPIO_PinState yPin_p_state = HAL_GPIO_ReadPin(ySW_pos.port, ySW_pos.pin);
-    GPIO_PinState yPin_n_state = HAL_GPIO_ReadPin(ySW_neg.port, ySW_neg.pin);
-    GPIO_PinState zPin_p_state = HAL_GPIO_ReadPin(zSW_pos.port, zSW_pos.pin);
-    GPIO_PinState zPin_n_state = HAL_GPIO_ReadPin(zSW_neg.port, zSW_neg.pin);
-
     // Y+
-    if (ySW_pos.Pin_state != yPin_p_state)
+    if ((now - ySW_pos.lastDebounceTime) > LIMIT_SWITCH_DEBOUNCE_MS)
     {
-        HAL_GPIO_EXTI_IRQHandler(ySW_pos.pin); // Always clear IRQ
-
-        if (DEBOUNCE_OK(ySW_pos.lastDebounceTime, now))
+        ySW_pos.lastDebounceTime = now;
+        GPIO_PinState new_state = HAL_GPIO_ReadPin(ySW_pos.port, ySW_pos.pin);
+        if (ySW_pos.Pin_state != new_state)
         {
-            ySW_pos.lastDebounceTime = now;
-            if (yPin_p_state)
+            ySW_pos.Pin_state = new_state;
+            if (new_state)
             {
                 motorY.isMoving = 0;
                 LOG_INFO("Y+ Engaged");
@@ -110,19 +106,18 @@ void EXTI9_5_IRQHandler(void)
                 LOG_INFO("Y+ Disengaged");
             }
         }
-
-        ySW_pos.Pin_state = yPin_p_state;
     }
+    HAL_GPIO_EXTI_IRQHandler(ySW_pos.pin);
 
     // Y-
-    if (ySW_neg.Pin_state != yPin_n_state)
+    if ((now - ySW_neg.lastDebounceTime) > LIMIT_SWITCH_DEBOUNCE_MS)
     {
-        HAL_GPIO_EXTI_IRQHandler(ySW_neg.pin);
-
-        if (DEBOUNCE_OK(ySW_neg.lastDebounceTime, now))
+        ySW_neg.lastDebounceTime = now;
+        GPIO_PinState new_state = HAL_GPIO_ReadPin(ySW_neg.port, ySW_neg.pin);
+        if (ySW_neg.Pin_state != new_state)
         {
-            ySW_neg.lastDebounceTime = now;
-            if (yPin_n_state)
+            ySW_neg.Pin_state = new_state;
+            if (new_state)
             {
                 motorY.isMoving = 0;
                 LOG_INFO("Y- Engaged");
@@ -132,19 +127,18 @@ void EXTI9_5_IRQHandler(void)
                 LOG_INFO("Y- Disengaged");
             }
         }
-
-        ySW_neg.Pin_state = yPin_n_state;
     }
+    HAL_GPIO_EXTI_IRQHandler(ySW_neg.pin);
 
     // Z+
-    if (zSW_pos.Pin_state != zPin_p_state)
+    if ((now - zSW_pos.lastDebounceTime) > LIMIT_SWITCH_DEBOUNCE_MS)
     {
-        HAL_GPIO_EXTI_IRQHandler(zSW_pos.pin);
-
-        if (DEBOUNCE_OK(zSW_pos.lastDebounceTime, now))
+        zSW_pos.lastDebounceTime = now;
+        GPIO_PinState new_state = HAL_GPIO_ReadPin(zSW_pos.port, zSW_pos.pin);
+        if (zSW_pos.Pin_state != new_state)
         {
-            zSW_pos.lastDebounceTime = now;
-            if (zPin_p_state)
+            zSW_pos.Pin_state = new_state;
+            if (new_state)
             {
                 motorZ.isMoving = 0;
                 LOG_INFO("Z+ Engaged");
@@ -154,19 +148,18 @@ void EXTI9_5_IRQHandler(void)
                 LOG_INFO("Z+ Disengaged");
             }
         }
-
-        zSW_pos.Pin_state = zPin_p_state;
     }
+    HAL_GPIO_EXTI_IRQHandler(zSW_pos.pin);
 
     // Z-
-    if (zSW_neg.Pin_state != zPin_n_state)
+    if ((now - zSW_neg.lastDebounceTime) > LIMIT_SWITCH_DEBOUNCE_MS)
     {
-        HAL_GPIO_EXTI_IRQHandler(zSW_neg.pin);
-
-        if (DEBOUNCE_OK(zSW_neg.lastDebounceTime, now))
+        zSW_neg.lastDebounceTime = now;
+        GPIO_PinState new_state = HAL_GPIO_ReadPin(zSW_neg.port, zSW_neg.pin);
+        if (zSW_neg.Pin_state != new_state)
         {
-            zSW_neg.lastDebounceTime = now;
-            if (zPin_n_state)
+            zSW_neg.Pin_state = new_state;
+            if (new_state)
             {
                 motorZ.isMoving = 0;
                 LOG_INFO("Z- Engaged");
@@ -176,7 +169,6 @@ void EXTI9_5_IRQHandler(void)
                 LOG_INFO("Z- Disengaged");
             }
         }
-
-        zSW_neg.Pin_state = zPin_n_state;
     }
+    HAL_GPIO_EXTI_IRQHandler(zSW_neg.pin);
 }

--- a/src/limit_switch_hal.c
+++ b/src/limit_switch_hal.c
@@ -7,7 +7,7 @@
 void EXTI9_5_IRQHandler(void);
 void Switch_Init(InterruptSwitch *interruptSW);
 
-#define LIMIT_SWITCH_DEBOUNCE_MS 10  // Software debounce time in milliseconds
+#define LIMIT_SWITCH_DEBOUNCE_MS 20 // Tuned software debounce time
 #define DEBOUNCE_OK(last_time, now) ((now - last_time) > LIMIT_SWITCH_DEBOUNCE_MS)
 
 InterruptSwitch ySW_pos =
@@ -15,32 +15,28 @@ InterruptSwitch ySW_pos =
         .name = "ySwitchPos",
         .port = GPIOB,
         .pin = GPIO_PIN_9,
-        .lastDebounceTime = 0
-};
+        .lastDebounceTime = 0};
 
 InterruptSwitch ySW_neg =
     {
         .name = "ySwitchNeg",
         .port = GPIOB,
         .pin = GPIO_PIN_8,
-        .lastDebounceTime = 0
-};
+        .lastDebounceTime = 0};
 
 InterruptSwitch zSW_pos =
     {
         .name = "zSwitchPos",
         .port = GPIOB,
         .pin = GPIO_PIN_6,
-        .lastDebounceTime = 0
-};
+        .lastDebounceTime = 0};
 
 InterruptSwitch zSW_neg =
     {
         .name = "zSwitchNeg",
         .port = GPIOB,
         .pin = GPIO_PIN_5,
-        .lastDebounceTime = 0
-};
+        .lastDebounceTime = 0};
 
 /**
  * @brief Initializes the pins and state of the limit switch / pi interrupt.
@@ -70,7 +66,6 @@ void Limit_Switch_Init(void)
     Switch_Init(&zSW_pos);
     Switch_Init(&zSW_neg);
 
-    // Enable and set EXTI line Interrupt to the given priority
     HAL_NVIC_SetPriority(EXTI9_5_IRQn, 0, 0);
     HAL_NVIC_EnableIRQ(EXTI9_5_IRQn);
 }
@@ -90,74 +85,98 @@ void EXTI9_5_IRQHandler(void)
         return;
     }
 
-    uint32_t now = HAL_GetTick();  // Get current system time
+    uint32_t now = HAL_GetTick();
 
     GPIO_PinState yPin_p_state = HAL_GPIO_ReadPin(ySW_pos.port, ySW_pos.pin);
     GPIO_PinState yPin_n_state = HAL_GPIO_ReadPin(ySW_neg.port, ySW_neg.pin);
     GPIO_PinState zPin_p_state = HAL_GPIO_ReadPin(zSW_pos.port, zSW_pos.pin);
     GPIO_PinState zPin_n_state = HAL_GPIO_ReadPin(zSW_neg.port, zSW_neg.pin);
 
-    if (ySW_pos.Pin_state != yPin_p_state && DEBOUNCE_OK(ySW_pos.lastDebounceTime, now))
+    // Y+
+    if (ySW_pos.Pin_state != yPin_p_state)
     {
-        ySW_pos.lastDebounceTime = now;
-        if (yPin_p_state)
+        HAL_GPIO_EXTI_IRQHandler(ySW_pos.pin); // Always clear IRQ
+
+        if (DEBOUNCE_OK(ySW_pos.lastDebounceTime, now))
         {
-            motorY.isMoving = 0;
-            LOG_INFO("Y+ Engaged");
+            ySW_pos.lastDebounceTime = now;
+            if (yPin_p_state)
+            {
+                motorY.isMoving = 0;
+                LOG_INFO("Y+ Engaged");
+            }
+            else
+            {
+                LOG_INFO("Y+ Disengaged");
+            }
         }
-        else
-        {
-            LOG_INFO("Y+ Disengaged");
-        }
-        HAL_GPIO_EXTI_IRQHandler(ySW_pos.pin);
+
         ySW_pos.Pin_state = yPin_p_state;
     }
 
-    if (ySW_neg.Pin_state != yPin_n_state && DEBOUNCE_OK(ySW_neg.lastDebounceTime, now))
+    // Y-
+    if (ySW_neg.Pin_state != yPin_n_state)
     {
-        ySW_neg.lastDebounceTime = now;
-        if (yPin_n_state)
-        {
-            motorY.isMoving = 0;
-            LOG_INFO("Y- Engaged");
-        }
-        else
-        {
-            LOG_INFO("Y- Disengaged");
-        }
         HAL_GPIO_EXTI_IRQHandler(ySW_neg.pin);
+
+        if (DEBOUNCE_OK(ySW_neg.lastDebounceTime, now))
+        {
+            ySW_neg.lastDebounceTime = now;
+            if (yPin_n_state)
+            {
+                motorY.isMoving = 0;
+                LOG_INFO("Y- Engaged");
+            }
+            else
+            {
+                LOG_INFO("Y- Disengaged");
+            }
+        }
+
         ySW_neg.Pin_state = yPin_n_state;
     }
 
-    if (zSW_pos.Pin_state != zPin_p_state && DEBOUNCE_OK(zSW_pos.lastDebounceTime, now))
+    // Z+
+    if (zSW_pos.Pin_state != zPin_p_state)
     {
-        zSW_pos.lastDebounceTime = now;
-        if (zPin_p_state)
-        {
-            motorZ.isMoving = 0;
-            LOG_INFO("Z+ Engaged");
-        }
-        else
-        {
-            LOG_INFO("Z+ Disengaged");
-        }
         HAL_GPIO_EXTI_IRQHandler(zSW_pos.pin);
+
+        if (DEBOUNCE_OK(zSW_pos.lastDebounceTime, now))
+        {
+            zSW_pos.lastDebounceTime = now;
+            if (zPin_p_state)
+            {
+                motorZ.isMoving = 0;
+                LOG_INFO("Z+ Engaged");
+            }
+            else
+            {
+                LOG_INFO("Z+ Disengaged");
+            }
+        }
+
         zSW_pos.Pin_state = zPin_p_state;
     }
 
-    if (zSW_neg.Pin_state != zPin_n_state && DEBOUNCE_OK(zSW_neg.lastDebounceTime, now))
+    // Z-
+    if (zSW_neg.Pin_state != zPin_n_state)
     {
-        zSW_neg.lastDebounceTime = now;
-        if (zPin_n_state)
-        {
-            motorZ.isMoving = 0;
-            LOG_INFO("Z- Engaged");
-        }
-        else
-        {
-            LOG_INFO("Z- Disengaged");
-        }
         HAL_GPIO_EXTI_IRQHandler(zSW_neg.pin);
+
+        if (DEBOUNCE_OK(zSW_neg.lastDebounceTime, now))
+        {
+            zSW_neg.lastDebounceTime = now;
+            if (zPin_n_state)
+            {
+                motorZ.isMoving = 0;
+                LOG_INFO("Z- Engaged");
+            }
+            else
+            {
+                LOG_INFO("Z- Disengaged");
+            }
+        }
+
         zSW_neg.Pin_state = zPin_n_state;
     }
 }

--- a/src/limit_switch_hal.c
+++ b/src/limit_switch_hal.c
@@ -5,57 +5,53 @@
 #include "drill_hal.h"
 
 void EXTI9_5_IRQHandler(void);
-void Switch_Init(InterruptSwitch *interruptSW);
+void Switch_Init(LimitSwitch *limitSW);
 
 #define LIMIT_SWITCH_DEBOUNCE_MS 20
 
-InterruptSwitch ySW_pos =
-{
-    .name = "ySwitchPos",
-    .port = GPIOB,
-    .pin = GPIO_PIN_9,
-    .lastDebounceTime = 0
-};
+LimitSwitch ySW_pos =
+    {
+        .name = "ySwitchPos",
+        .port = GPIOB,
+        .pin = GPIO_PIN_9,
+        .lastDebounceTime = 0};
 
-InterruptSwitch ySW_neg =
-{
-    .name = "ySwitchNeg",
-    .port = GPIOB,
-    .pin = GPIO_PIN_8,
-    .lastDebounceTime = 0
-};
+LimitSwitch ySW_neg =
+    {
+        .name = "ySwitchNeg",
+        .port = GPIOB,
+        .pin = GPIO_PIN_8,
+        .lastDebounceTime = 0};
 
-InterruptSwitch zSW_pos =
-{
-    .name = "zSwitchPos",
-    .port = GPIOB,
-    .pin = GPIO_PIN_6,
-    .lastDebounceTime = 0
-};
+LimitSwitch zSW_pos =
+    {
+        .name = "zSwitchPos",
+        .port = GPIOB,
+        .pin = GPIO_PIN_6,
+        .lastDebounceTime = 0};
 
-InterruptSwitch zSW_neg =
-{
-    .name = "zSwitchNeg",
-    .port = GPIOB,
-    .pin = GPIO_PIN_5,
-    .lastDebounceTime = 0
-};
+LimitSwitch zSW_neg =
+    {
+        .name = "zSwitchNeg",
+        .port = GPIOB,
+        .pin = GPIO_PIN_5,
+        .lastDebounceTime = 0};
 
 /**
- * @brief Initializes the pins and state of the limit switch / pi interrupt.
+ * @brief Initializes the pins and state of the limit switch
  *
- * @param interruptSW Interrupt switch object.
+ * @param limitSW Interrupt switch object.
  */
-void Switch_Init(InterruptSwitch *interruptSW)
+void Switch_Init(LimitSwitch *limitSW)
 {
     GPIO_InitTypeDef GPIO_InitStruct = {0};
 
-    GPIO_InitStruct.Pin = interruptSW->pin;
+    GPIO_InitStruct.Pin = limitSW->pin;
     GPIO_InitStruct.Mode = GPIO_MODE_IT_RISING_FALLING;
     GPIO_InitStruct.Pull = GPIO_NOPULL;
-    HAL_GPIO_Init(interruptSW->port, &GPIO_InitStruct);
+    HAL_GPIO_Init(limitSW->port, &GPIO_InitStruct);
 
-    interruptSW->Pin_state = HAL_GPIO_ReadPin(interruptSW->port, interruptSW->pin);
+    limitSW->Pin_state = HAL_GPIO_ReadPin(limitSW->port, limitSW->pin);
 }
 
 /**

--- a/src/main.c
+++ b/src/main.c
@@ -31,6 +31,7 @@ int main(void)
 
   // Wait for Pi to boot to avoid unintentional movement
   Serial_Init();
+  LOG_INFO("\n\n\n\n\n\n\n");
   Motors_Init();
   HAL_GPIO_WritePin(motorY.sleepPort, motorY.sleepPin, GPIO_PIN_RESET); // Unstall y motor
   HAL_GPIO_WritePin(motorZ.sleepPort, motorZ.sleepPin, GPIO_PIN_RESET); // Unstall z motor
@@ -66,7 +67,7 @@ int main(void)
             HomeMotors();
           }
           locateWeed(weedPos);
-          removeWeed(weedPos, 25);
+          removeWeed(weedPos, 5);
         }
         else
         {

--- a/src/main.c
+++ b/src/main.c
@@ -31,7 +31,7 @@ int main(void)
 
   // Wait for Pi to boot to avoid unintentional movement
   Serial_Init();
-  LOG_INFO("\n\n\n\n\n\n\n");
+  LOG_INFO("\n\n\n\n\n"); // Readability between resets
   Motors_Init();
   HAL_GPIO_WritePin(motorY.sleepPort, motorY.sleepPin, GPIO_PIN_RESET); // Unstall y motor
   HAL_GPIO_WritePin(motorZ.sleepPort, motorZ.sleepPin, GPIO_PIN_RESET); // Unstall z motor

--- a/src/main.c
+++ b/src/main.c
@@ -31,7 +31,7 @@ int main(void)
 
   // Wait for Pi to boot to avoid unintentional movement
   Serial_Init();
-  LOG_INFO("\n\n\n\n\n"); // Readability between resets
+  printf("\n\n\n\n\n"); // Readability between resets
   Motors_Init();
   HAL_GPIO_WritePin(motorY.sleepPort, motorY.sleepPin, GPIO_PIN_RESET); // Unstall y motor
   HAL_GPIO_WritePin(motorZ.sleepPort, motorZ.sleepPin, GPIO_PIN_RESET); // Unstall z motor

--- a/src/motor_hal.c
+++ b/src/motor_hal.c
@@ -333,16 +333,16 @@ void HomeMotors(void)
     }
     HAL_Delay(1000);
 
-    // Move right/down by 5mm
-    MoveBy(-5, -5);
+    // Move right/down by 7.5mm
+    MoveBy(-7.5, -7.5);
     while (motorsMoving())
     {
         HAL_Delay(1);
     }
 
     // Update min position to avoid limit switch contact
-    motorY.posMax -= 6.21; // As measured for 5mm command 12-FEB-2025 ED
-    motorZ.posMax -= 7.21; // As measured for 5mm command 12-FEB-2025 ED
+    motorY.posMax -= 8.71; // As measured for 5mm command 12-FEB-2025 ED - 2.5mm 12-MAR-2025 ED
+    motorZ.posMax -= 9.71; // As measured for 5mm command 12-FEB-2025 ED - 2.5mm 12-MAR-2025 ED
 
     state.y = motorY.posMax;
     state.z = motorZ.posMax;

--- a/src/motor_hal.c
+++ b/src/motor_hal.c
@@ -334,22 +334,22 @@ void HomeMotors(void)
     HAL_Delay(500);
 
     // Back off Y by 7.5mm
-    MoveBy(-7.5, 0);
+    MoveBy(-5, 0);
     while (motorsMoving())
     {
         HAL_Delay(1);
     }
 
     // Back off Z by 7.5mm. Avoid doing both simultaneously, weird edge case
-    MoveBy(0, -7.5);
+    MoveBy(0, -5);
     while (motorsMoving())
     {
         HAL_Delay(1);
     }
 
     // Update min position to avoid limit switch contact
-    motorY.posMax -= 8.71; // As measured for 5mm command 12-FEB-2025 ED - 2.5mm 12-MAR-2025 ED
-    motorZ.posMax -= 9.71; // As measured for 5mm command 12-FEB-2025 ED - 2.5mm 12-MAR-2025 ED
+    motorY.posMax -= 6.21; // As measured for 5mm command 12-FEB-2025 ED
+    motorZ.posMax -= 7.21; // As measured for 5mm command 12-FEB-2025 ED
 
     state.y = motorY.posMax;
     state.z = motorZ.posMax;

--- a/src/motor_hal.c
+++ b/src/motor_hal.c
@@ -331,10 +331,17 @@ void HomeMotors(void)
     {
         HAL_Delay(1);
     }
-    HAL_Delay(1000);
+    HAL_Delay(500);
 
-    // Move right/down by 7.5mm
-    MoveBy(-7.5, -7.5);
+    // Back off Y by 7.5mm
+    MoveBy(-7.5, 0);
+    while (motorsMoving())
+    {
+        HAL_Delay(1);
+    }
+
+    // Back off Z by 7.5mm. Avoid doing both simultaneously, weird edge case
+    MoveBy(0, -7.5);
     while (motorsMoving())
     {
         HAL_Delay(1);


### PR DESCRIPTION
Before update, Nucleo was facing unusual behaviour, such as:
- Freezing during homing procedure
- 1+ axes not moving if homing procedure did complete

Made the following changes to improve limit switch performance:
- Added software debouncing in addition to existing hardware debouncing. Set to 20ms to match hardware. Tried some other values but this worked best.
- When 'backing off' during homing, system now does Y then Z. Doing both simultaneously confused the system if both switches disengaged at precisely the same time
- Removed all reference to Pi interrupt line since we won't be using it (Using RESET instead). Improves readability.

Results:
- Ran 10 successful tests in a row last night, video here -> \9 Other\1 Photos and Videos\!misc\20250312 - Limit Switch Test Timelapse.MOV
- 7 more successful tests this morning. Followed by ~10 more where I just let it home, back off, then I reset. Cycle always works as expected.
- NOTE: Only observed bug is that sometimes when backing off (Say 1 in 15 times), z+ shows disengaged before y+, even though y backs off first. This has had no negative impacts on the cycle, so low priority.